### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/auto-accept-dependabot.yml
+++ b/.github/workflows/auto-accept-dependabot.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 
       - name: set up go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4.1.0
         with:
           go-version: "1.21"
 
       - name: cache go modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -51,7 +51,7 @@ jobs:
           go test -v ./...
 
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v5.0.0
         if: success() && startsWith(github.ref, 'refs/tags/')
         with:
           version: latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.0.0
         with:
           fetch-depth: 0
 
       - name: set up go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4.1.0
         with:
           go-version: "1.21"
 
       - name: cache go modules
-        uses: actions/cache@v1
+        uses: actions/cache@v3.3.2
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.0.0
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.AUTO_UPDATE_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)** on 2023-09-04T12:22:57Z
* **[goreleaser/goreleaser-action](https://github.com/goreleaser/goreleaser-action)** published a new release **[v5.0.0](https://github.com/goreleaser/goreleaser-action/releases/tag/v5.0.0)** on 2023-09-11T18:09:55Z
* **[actions/setup-go](https://github.com/actions/setup-go)** published a new release **[v4.1.0](https://github.com/actions/setup-go/releases/tag/v4.1.0)** on 2023-08-08T12:04:32Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v3.3.2](https://github.com/actions/cache/releases/tag/v3.3.2)** on 2023-09-07T20:33:08Z
